### PR TITLE
Fix evil-multiedit--get-occurrence to properly match words

### DIFF
--- a/evil-multiedit.el
+++ b/evil-multiedit.el
@@ -435,7 +435,7 @@ selected area is the boundary for matches. If BANG, invert
              (setq bounds (bounds-of-thing-at-point 'symbol)))
             ((bounds-of-thing-at-point 'word)
              (setq regexp
-                   (format "\\_<%s\\_>"
+                   (format "\\<%s\\>"
                            (regexp-quote (thing-at-point 'word t))))
              (setq bounds (bounds-of-thing-at-point 'word))))
       (list regexp (car bounds) (cdr bounds)))))

--- a/test/evil-multiedit-test.el
+++ b/test/evil-multiedit-test.el
@@ -15,17 +15,17 @@
   :tags '(evil-multiedit)
   (with! "The qu|ick brown fox was as quick as quick can be"
     (should (= 1 (evil-multiedit-match-and-prev)))
-    (should (string= iedit-initial-string-local "\\_<quick\\_>"))
+    (should (string= iedit-initial-string-local "\\<quick\\>"))
     (should-error (evil-multiedit-match-and-prev)))
   (with! "The quick brown fox was as qu|ick as quick can be"
     (should (= 1 (evil-multiedit-match-and-next)))
-    (should (string= iedit-initial-string-local "\\_<quick\\_>"))
+    (should (string= iedit-initial-string-local "\\<quick\\>"))
     (should (= 2 (evil-multiedit-match-and-next)))
     (should (= 3 (evil-multiedit-match-and-prev)))
-    (should (string= iedit-initial-string-local "\\_<quick\\_>"))
+    (should (string= iedit-initial-string-local "\\<quick\\>"))
     (should-error (evil-multiedit-match-and-next))
     (should-error (evil-multiedit-match-and-prev))
-    (should (string= iedit-initial-string-local "\\_<quick\\_>"))))
+    (should (string= iedit-initial-string-local "\\<quick\\>"))))
 
 (ert-deftest evil-multiedit-incremental-visual-match-backward-test ()
   :tags '(evil-multiedit)


### PR DESCRIPTION
Previously, when calling a function like `evil-multiedit-match-and-next`, multiedit would read the word at the current point but then would try to match symbols that match that word. This presents a problem when symbols can contain multiple words (as in the default emacs-lisp syntax table).

For example, in the following snippet...

```elisp
(setq foo-bar 123
      foo-baz 456)
```

...calling `evil-multiedit-match-and-next` while the cursor is on the first instance of `foo` would fail as there are zero symbols matching `foo`.