### PR TITLE
Add functions for aligning cursors

### DIFF
--- a/evil-multiedit.el
+++ b/evil-multiedit.el
@@ -365,6 +365,31 @@ multiedit region beneath the cursor, if one exists."
       (evil-normal-state))))
 
 ;;;###autoload
+(defun evil-mc-vertical-align (character)
+  "Vertically aligns all cursors with a given CHARACTER to the rightmost one.
+Might not behave as intended if more than one cursors are on the same line."
+  (interactive "c")
+  (let ((rightest-column (current-column)))
+    (evil-mc-execute-for-all-cursors
+     (lambda (x) "get the rightest cursor"
+       (interactive)
+       (setq rightest-column (max (current-column) rightest-column))
+       ))
+    (evil-mc-execute-for-all-cursors
+     (lambda (x) "Insert the necessary spaces"
+       (interactive)
+       (let ((missing-spaces (- rightest-column (current-column))))
+         (save-excursion (insert (make-string missing-spaces character)))
+         (forward-char missing-spaces))))))
+
+;;;###autoload
+(defun evil-mc-vertical-align-with-space ()
+  "Vertically aligns all cursors with spaces to the rightmost one.
+Might not behave as intended if more than one cursors are on the same line."
+  (interactive)
+  (evil-mc-vertical-align 32))
+
+;;;###autoload
 (defun evil-multiedit-insert-state-escape ()
   "Exit to `evil-multiedit-state' and move the cursor back one, to be consistent
 with behavior when exiting vanilla insert state."


### PR DESCRIPTION
This function is adapted from multiple-cursors.el here:
https://github.com/magnars/multiple-cursors.el/blob/b9b851a7670f4348f3a08b11ef12ed99676c8b84/mc-separate-operations.el#L125-L147

`evil-mc-vertical-align` aligns all cursors to the rightmost one using
CHARACTER. `evil-mc-vertical-align-with-space` simply calls the first
function with space as an argument (character 32)