### PR TITLE
save deleted region to killring when "C" or "D"

### DIFF
--- a/evil-multiedit.el
+++ b/evil-multiedit.el
@@ -583,7 +583,7 @@ state."
   (iedit-barf-if-buffering)
   (save-excursion
     (dolist (occurrence iedit-occurrences-overlays)
-      (delete-region (overlay-start occurrence) (overlay-end occurrence)))))
+      (kill-region (overlay-start occurrence) (overlay-end occurrence)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/evil-multiedit.el
+++ b/evil-multiedit.el
@@ -581,9 +581,14 @@ state."
   "Delete occurrences."
   (interactive "*")
   (iedit-barf-if-buffering)
-  (save-excursion
-    (dolist (occurrence iedit-occurrences-overlays)
-      (kill-region (overlay-start occurrence) (overlay-end occurrence)))))
+  (when iedit-occurrences-overlays
+    (save-excursion
+      (kill-new
+       (buffer-substring-no-properties
+        (overlay-start (car iedit-occurrences-overlays))
+        (overlay-end (car iedit-occurrences-overlays))))
+      (dolist (occurrence iedit-occurrences-overlays)
+        (delete-region (overlay-start occurrence) (overlay-end occurrence))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
I often find it frustrating when I `C`/`D` and the deleted region is not saved to killring.